### PR TITLE
fix: restore landing route and harden /api/analyze (coach + decision)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import { AppProvider, useApp } from "./contexts/AppContext";
-import EnhancedLandingPage from "./pages/EnhancedLandingPage"; // ✅ default import
+import { LandingPage } from "./pages/LandingPage"; // ✅ named export
 import OnboardingChat from "./pages/OnboardingChat";           // ✅ default export
 import Dashboard from "./pages/Dashboard";
 import { DecisionCompassPage } from "./pages/DecisionCompassPage"; // named export
@@ -11,7 +11,7 @@ const AppRoutes: React.FC = () => {
   const { state } = useApp();
   return (
     <Routes>
-      <Route path="/" element={<EnhancedLandingPage />} />
+      <Route path="/" element={<LandingPage />} />
       <Route path="/onboarding" element={<OnboardingChat />} />
       <Route
         path="/dashboard"

--- a/src/pages/OnboardingChat.tsx
+++ b/src/pages/OnboardingChat.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Sparkles, Send, CheckCircle2, Mic, Square, Wand2 } from "lucide-react";
 import { CinematicButton } from "../components/ui/CinematicButton";
 import BreathingNorthStar from "../components/BreathingNorthStar";
-import { analyze } from "../services/api";
+import { coachMessage } from "../services/api";
 import { profileStore } from "../services/profileStore";
 import { useApp } from "../contexts/AppContext";
 
@@ -101,21 +101,17 @@ export default function OnboardingChat() {
     setLoading(true);
 
     try {
-      const result = await analyze(next);
+      const result = await coachMessage(userText, profileStore.get());
       const reply: Msg = { role: "assistant", content: result.reply ?? "Noted. Tell me a bit more." };
 
       // Persist any stitched profile data
-      if (result.profileFragment) profileStore.merge(result.profileFragment);
+      if (result.profilePatch) profileStore.merge(result.profilePatch);
 
       // Compose: model reply + our purposeful next question
       const followUp = nextSmartQuestion([...next, reply]);
       const augmented = [...next, reply, { role: "assistant", content: followUp } as Msg];
 
       setMessages(augmented);
-
-      if (result.readyForDashboard) {
-        dispatch({ type: "COMPLETE_ONBOARDING" });
-      }
     } catch {
       setMessages((prev) => [
         ...prev,


### PR DESCRIPTION
## Summary
- restore original `LandingPage` at `/`
- rewrite `analyze` Netlify function to accept onboarding and decision payloads with safe Anthropic fallbacks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a7efab547c832083abfbc212bdc052